### PR TITLE
Use background-color when hovering links

### DIFF
--- a/public/global.scss
+++ b/public/global.scss
@@ -14,7 +14,8 @@
   --color-text: #bbb;
   --color-subtext: #777;
   --color-faded: #444;
-  --color-link: #99aa99;
+  --color-link-rgb: 153, 170, 153;
+  --color-link: rgb(var(--color-link-rgb));
   --color-backgroundNav: #000;
   --spacing: 20px;
   --base-font-size: clamp(100%, 1rem + 0.5vw, 21px);
@@ -92,19 +93,7 @@ a {
   &:focus {
     text-decoration-color: var(--color-title);
     color: var(--color-title);
-
-    &:before {
-      content: "";
-      width: 100%;
-      height: 3px;
-      position: absolute;
-      left: 0px;
-      right: 0px;
-      height: 100%;
-      background: var(--color-link);
-      z-index: 1;
-      opacity: 0.2;
-    }
+    background-color: rgba(var(--color-link-rgb), 0.2);
   }
 }
 


### PR DESCRIPTION
Hi Robin! Robin here.

I've really enjoyed following you and your writing the past couple of years! Thank you for that.

I'll get to the point: I like your new homepage design—but the way links are styled when hovered is a bit buggy for me.

<img width="600" alt="Screenshot 2021-10-07 at 10 03 19" src="https://user-images.githubusercontent.com/35560568/136344651-2a76f1bf-d269-4ff4-bb4a-06dfd714945e.png">

☝️ _Looks good_

<img width="600" alt="Screenshot 2021-10-07 at 10 03 35" src="https://user-images.githubusercontent.com/35560568/136344653-a95b703e-e1d6-4315-8108-95299ed377d1.png">

☝️ _Only highlights on the first line when wrapping_

<img width="600" alt="Screenshot 2021-10-07 at 10 03 06" src="https://user-images.githubusercontent.com/35560568/136344647-110ed47f-1c4b-4604-87c1-8773a4609d89.png">

☝️ _Sometimes has weird positioning bugs_ (could be fixed by adding `top:0;bottom:0;` to the absolutely  positioned pseudo-element, but doesn't fix the line wrapping issue)

---

I suggest simply using a transparent `background-color` instead of the pseudo-element, this will fix the issues and make the code lighter and simpler 🙂 

There are several ways to do this:

- Add a new CSS variable with the transparent `color-link` (i.e. in rgba) 👉 the downside here is that you'd have to duplicate your color
- Use Sass's color features, like [`rgba()`](https://sass-lang.com/documentation/modules#rgba) or [`transparentize`](https://sass-lang.com/documentation/modules/color#transparentize), to add alpha to a hex color 👉 this would be the cleanest probably, but to do this you can't use CSS variables (which are runtime), you'd need to switch to [Sass variables](https://sass-lang.com/documentation/variables) (which are compile-time)
- Create a `--color-link-rgb` variable that holds the comma-separated R, G and B values for your color (`153, 170, 153`) and use it in `--color-link` like `rgb(var(--color-link-rgb))`, and for your transparent background-color like `rgba(var(--color-link-rbg), 0.2)` 👉 that's what this PR suggests, but eventually it's up to you 🙂 

<img width="600" alt="Screenshot 2021-10-07 at 10 18 07" src="https://user-images.githubusercontent.com/35560568/136346658-0a8c5d21-d4fc-4519-8386-a1a7dc825692.png">

Take care!