### PR TITLE
Nav bug on mobile 🐞

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -800,6 +800,7 @@
 
       .hover-svg {
         position: absolute;
+        z-index: -1;
       }
 
       .tmpl-post h2 {


### PR DESCRIPTION
I was reading your latest note on my iPhone and was having trouble navigating between routes in the `<nav>` . It looks like the new dope SVG distressed text you added _(which is f*cking sick btw)_ was causing a bug on mobile.

<img width="966" alt="Screen Shot 2022-12-29 at 2 15 41 PM" src="https://user-images.githubusercontent.com/4982985/210016205-ee08515a-d151-4596-b109-7901d029b659.png">

I tested this on my local build and my iPhone (http://10.0.0.20:8080/) and it looked and worked great. It was literally one dumb line of code lol

✌️ Manhart
